### PR TITLE
歩数の合計方法を修正

### DIFF
--- a/android/src/main/java/com/reactnative/googlefit/StepHistory.java
+++ b/android/src/main/java/com/reactnative/googlefit/StepHistory.java
@@ -279,16 +279,12 @@ public class StepHistory {
             Log.i(TAG, "\t\tType : " + dp.getDataType().getName());
             Log.i(TAG, "\t\tStart: " + dateFormat.format(dp.getStartTime(TimeUnit.MILLISECONDS)));
             Log.i(TAG, "\t\tEnd  : " + dateFormat.format(dp.getEndTime(TimeUnit.MILLISECONDS)));
+            Log.i(TAG, "\t\tValue: " + dp.getValue(Field.FIELD_STEPS));
 
-            for(Field field : dp.getDataType().getFields()) {
-                Log.i(TAG, "\t\tField: " + field.getName() +
-                        " Value: " + dp.getValue(field));
-
-                stepMap.putDouble("startDate", dp.getStartTime(TimeUnit.MILLISECONDS));
-                stepMap.putDouble("endDate", dp.getEndTime(TimeUnit.MILLISECONDS));
-                stepMap.putDouble("steps", dp.getValue(field).asInt());
-                map.pushMap(stepMap);
-            }
+            stepMap.putDouble("startDate", dp.getStartTime(TimeUnit.MILLISECONDS));
+            stepMap.putDouble("endDate", dp.getEndTime(TimeUnit.MILLISECONDS));
+            stepMap.putDouble("steps", dp.getValue(Field.FIELD_STEPS).asInt());
+            map.pushMap(stepMap);
         }
     }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -7,7 +7,9 @@ export function buildDailySteps(steps) {
       continue
     }
 
-    const dateFormatted = getFormattedDate(new Date(step.endDate))
+    // 日付を跨いだセッションデータがある場合endDateには次の日の０時０分０秒が入るので
+    // startDateを基準に同じ日付の値を合計する
+    const dateFormatted = getFormattedDate(new Date(step.startDate))
 
     if (!(dateFormatted in results)) {
       results[dateFormatted] = 0
@@ -18,7 +20,7 @@ export function buildDailySteps(steps) {
 
   const dateMap = []
   for (const index in results) {
-    //PepUp use startDate key
+    // PepUp use startDate key
     dateMap.push({startDate: index, value: results[index]})
   }
   return dateMap


### PR DESCRIPTION
# 問題
日付を跨いで歩いた場合、歩数が次の日に加算され、GoogleFitアプリとPepUpアプリで表示に差があった
https://hdpinc.atlassian.net/jira/software/projects/PPAP/boards/53?selectedIssue=PPAP-224

# 原因
GoogleFitから1日単位で歩数を取得した時終了が次の日の0時になる。
複数のData point を考慮して最後に歩数の合計をする際に終了時刻を基準にして計算していたために
日付を跨いだ場合次の日の記録扱いになってしまっていた。

```
Data point:
	Type : com.google.step_count.delta
	Start: 2021-05-22T12:32:00.000+0900
	End  : 2021-05-23T00:00:00.000+0900
	Value: 6333
Data point:
	Type : com.google.step_count.delta
	Start: 2021-05-23T00:00:00.000+0900
	End  : 2021-05-23T10:24:00.000+0900
	Value: 8667
```

# 確認内容
GoogleFitで以下のアクティビティを登録
5/22 12:00 ~ 5/22 13:00 　5000歩
5/22 22:24 ~ 5/23 10:24    10000歩

GoogleFIt的には　5/22 は6333歩 5/23 は8667歩扱いになる
![Screenshot_20210523-141453](https://user-images.githubusercontent.com/45444259/119249685-85136100-bbd5-11eb-953a-cbf1ed375ec9.png)

PepUpでGoogleFitと同じ値が表示されていることを確認
![Screenshot_20210523-141513](https://user-images.githubusercontent.com/45444259/119249711-b3913c00-bbd5-11eb-9d60-a7d58d41d16b.png)
![Screenshot_20210523-141504](https://user-images.githubusercontent.com/45444259/119249713-b5f39600-bbd5-11eb-822f-78405f206440.png)

